### PR TITLE
Deploy/cloud run backend update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY backend/ /app/
 RUN mkdir -p static
 
 # Expose the port the app runs on
-EXPOSE 5000
+EXPOSE 8080
 
 # Command to run the application
-CMD ["python", "app.py"] 
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "1", "--timeout", "120", "app:app"] 

--- a/backend/app.py
+++ b/backend/app.py
@@ -108,5 +108,5 @@ def verify_faces():
     })
 
 if __name__ == '__main__':
-    port = int(os.environ.get('PORT', 5000))
+    port = int(os.environ.get('PORT', 8080))
     app.run(host='0.0.0.0', port=port)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     depends_on:
       - backend
     environment:
-      - REACT_APP_BACKEND_URL=https://58a5-2405-201-6807-88d6-50a4-9f46-355-87cd.ngrok-free.app
+      - REACT_APP_BACKEND_URL=https://zynga-backend-493402296384.us-central1.run.app
       - PORT=3000
       - NODE_ENV=development
       - BROWSER=none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     depends_on:
       - backend
     environment:
-      - REACT_APP_BACKEND_URL=http://localhost:5000
+      - REACT_APP_BACKEND_URL=https://58a5-2405-201-6807-88d6-50a4-9f46-355-87cd.ngrok-free.app
       - PORT=3000
       - NODE_ENV=development
       - BROWSER=none

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 
 [build.environment]
   NODE_VERSION = "16"
-  REACT_APP_BACKEND_URL = "https://58a5-2405-201-6807-88d6-50a4-9f46-355-87cd.ngrok-free.app"
+  REACT_APP_BACKEND_URL = "https://zynga-backend-493402296384.us-central1.run.app"
 
 [[redirects]]
   from = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 
 [build.environment]
   NODE_VERSION = "16"
-  REACT_APP_BACKEND_URL = "https://codex-zynga-hackathon-1xkx.onrender.com"
+  REACT_APP_BACKEND_URL = "https://58a5-2405-201-6807-88d6-50a4-9f46-355-87cd.ngrok-free.app"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary by Sourcery

Configure backend to listen on port 8080 and update frontend to use the Cloud Run deployment URL

Enhancements:
- Default the backend service to the PORT environment variable set to 8080

Build:
- Expose port 8080 instead of 5000 in the Dockerfile

Deployment:
- Update REACT_APP_BACKEND_URL to the Cloud Run backend endpoint in docker-compose and Netlify configurations